### PR TITLE
✨ Feat: 1-10 영어 번역본 초안

### DIFF
--- a/codeexec.html
+++ b/codeexec.html
@@ -57,10 +57,10 @@
             </a>
         </h1>
         <a class="btn-download" onclick="downloadNotebook()">Download Notebook</a>
-        <a class="btn-exec" href="index.html">메인으로</a>
+        <a class="btn-exec" href="index.html">Go to Main</a>
     </header>
     <main>
-        <p class="info">💡 Shift-ENTER 또는 오른쪽 플레이 버튼을 누르면 실행됩니다. matplotlib은 plt.show대신 display(fig)를 사용하세요.</p>
+        <p class="info">💡 Press Shift-ENTER or the play button on the right to run. Use display(fig) instead of plt.show for matplotlib.</p>
         <py-repl id="my-repl" auto-generate="true"></py-repl>
     </main>
     <footer>

--- a/index.html
+++ b/index.html
@@ -126,16 +126,16 @@
         <div class="contents">
             <nav class="question-nav">
                 <ol>
-                    <li><a href="#" id="q1" class="btn-que">Q1. 자격 증명</a></li>
-                    <li><a href="#" id="q2" class="btn-que">Q2. 암호문</a></li>
-                    <li><a href="#" id="q3" class="btn-que">Q3. 출정인원 선발</a></li>
-                    <li><a href="#" id="q4" class="btn-que">Q4. 꿈의 설계</a></li>
-                    <li><a href="#" id="q5" class="btn-que">Q5. 상한 당근 찾기</a></li>
-                    <li><a href="#" id="q6" class="btn-que">Q6. 샌드위치 포장</a></li>
-                    <li><a href="#" id="q7" class="btn-que">Q7. 두 수의 합 찾기</a></li>
-                    <li><a href="#" id="q8" class="btn-que">Q8. 무기 생산</a></li>
-                    <li><a href="#" id="q9" class="btn-que">Q9. 최대 손실액</a></li>
-                    <li><a href="#" id="q10" class="btn-que">Q10. 알리는 포케가 좋아</a></li>
+                    <li><a href="#" id="q1" class="btn-que">Q1. Proof of Qualification</a></li>
+                    <li><a href="#" id="q2" class="btn-que">Q2. Cipher Text</a></li>
+                    <li><a href="#" id="q3" class="btn-que">Q3. Selecting Combat Participants</a></li>
+                    <li><a href="#" id="q4" class="btn-que">Q4. Dream Design</a></li>
+                    <li><a href="#" id="q5" class="btn-que">Q5. Finding a Rotten Carrot</a></li>
+                    <li><a href="#" id="q6" class="btn-que">Q6. Sandwich Packaging</a></li>
+                    <li><a href="#" id="q7" class="btn-que">Q7. Sum of Two Numbers</a></li>
+                    <li><a href="#" id="q8" class="btn-que">Q8. Weapon Production</a></li>
+                    <li><a href="#" id="q9" class="btn-que">Q9. Maximum Loss Amount</a></li>
+                    <li><a href="#" id="q10" class="btn-que">Q10. Ali's Poke Store</a></li>
                     <li><a href="#" id="q11" class="btn-que">Q11. Heoni spilled the latte</a></li>
                     <li><a href="#" id="q12" class="btn-que">Q12. Eat More Spicy Hot Pot</a></li>
                     <li><a href="#" id="q13" class="btn-que">Q13. Boarding the Flight</a></li>
@@ -191,12 +191,12 @@
                         </div>
                     </div>
                     <div class="btn-contain">
-                        <button id="btn-run" type="submit">채점하기</button>
+                        <button id="btn-run" type="submit">Submit</button>
                     </div>
 
                     <div id="result">
                         <h3>Result</h3>
-                        <div id="result_info">결과가 이 곳에 표시됩니다.</div>
+                        <div id="result_info">The result will be displayed here.</div>
                         <div id="result_desc"></div>
                     </div>
                     
@@ -208,7 +208,7 @@
                     <!-- chat -->
                     <article class="cont-chat close">
                         <h4 class="sr-only">인공지능에게 질문하기</h4>
-                        <p class="info"> 💡 복잡한 로직의 답변은 20초 이상의 시간이 걸릴 수 있습니다.</p>
+                        <p class="info"> 💡 Complex logic may take more than 20 seconds to respond.</p>
                         <div class="chatroom">
                             <ul class="chat-list">
                             </ul>
@@ -216,7 +216,7 @@
                         <form class="inp-chat" method="post">
                             <div>
                                 <textarea></textarea>
-                                <button type="submit">전송</button>
+                                <button type="submit">Send</button>
                             </div>
                         </form>
                         <button class="chat-close">

--- a/src/css/codeexec.css
+++ b/src/css/codeexec.css
@@ -162,7 +162,7 @@ py-terminal {
 }
 
 .py-repl-output:empty::after {
-	content: "> 터미널을 확인하세요";
+	content: "> Please check the terminal";
 	color: rgba(255, 255, 255, 0.5);
 }
 

--- a/src/pages/question1.md
+++ b/src/pages/question1.md
@@ -1,63 +1,55 @@
 - info
     - lv0
-    - 요구사항 구현
+    - Implementation
 
-# 자격 증명
-![제왕의 문](./1_1.webp)
+# Proof of Qualification
+![The King's Gate](./1_1.webp)
 
-## 문제 설명
-" 왕좌에 앉으려는 자! 자격을 증명하라!
+## Problem Description
+" Those who seek to sit on the throne! Prove your qualification!
 
-알고리즘 왕좌에 앉으려는 자는 자격을 증명해야 합니다. 만약 이 테스트를 '스스로' 통과하지 못한다면, 기본 문법을 다시 공부하고 와야 합니다. 앞으로 이보다 쉬운 문제는 없으니까요.
+Those who want to sit on the throne of algorithms must prove their qualification. If you cannot pass this test 'on your own,' you must review basic syntax and come back. There will be no easier problem than this one in the future.
 
-파이와 썬은 모든 알고리즘을 해독할 수 있는 알고리즘 7원석을 세계 어딘가에 숨겨두었다 공표하였습니다. 험난한 시련을 딛고 일어선 자만 이 시험을 통과할 수 있도록 설계되었습니다. 그가 남긴 문자는 아래와 같습니다.
+Pie and Sun have hidden the algorithm 7 stones that can decipher any algorithm somewhere in the world, and have announced it. It is designed so that only those who have overcome the harsh trials can pass this test. The text he left behind is as follows.
 
 ```py
-자격을 얻으려는 자! 이곳으로 향하라!
+Those who seek to qualify! Head this way!
 
 "  + +-+ -+-  "
 "  ++ -- +-+  "
 "  ++-+ -+ -  "
 "  + ++-+ -+  "
 
-해(1)와 달(0),
-Code의 세상 안으로! (En-Coding)
+Sun(1) and Moon(0),
+Into the world of Code! (En-Coding)
 ```
 
-![코딩의 제왕 파이와 썬](./1_2.webp)
+![The King of Coding, Pie and Sun](./1_2.webp)
 
-주어진 문자열을 1과 0으로 바꾸고 아스키 코드표 안에 문자로 바꾸세요.
-
----
-
-## 제한 사항
-
-- 65 ≤ 주어진 숫자 ≤ 122
-- 문자열은 `+`, `-`, `공백` 외에는 주어지지 않습니다.
-- 각각의 문자열은 1차원 리스트로 주어집니다.
-- 공백은 주어질 수도 있고, 주어지지 않을 수도 있습니다.
+Convert the given string to 1s and 0s and convert them into characters within the ASCII code table.
 
 ---
 
-## 입출력 예
+## Constraints
 
-|   입력    | 출력 |
+- 65 ≤ the given number ≤ 122
+- The string will not contain anything other than `+`, `-`, and `space`.
+- Each string will be given as a one-dimensional list.
+- The space may or may not be given.
+
+---
+
+## Input and Output Examples
+
+|  Input	|  Output  |
 | --------- | ------ |
-| ['  + - - + - + -  ', '  + + + - + - +  ', '  + + - + + + -  '] | 'Jun'    |
-| ['  + + + - - + +  ', '  + + + - + - -  ', '++----+', '+++ --+ -', '+++-+ - -'] | 'start'    |
-| ['  + + - - - - +  ', '  + + - + + - -  ', '+ +-- +++  ', '  ++- ++++'] | 'algo'    |
+| [' + - - + - + - ', ' + + + - + - + ', ' + + - + + + - ']	| 'Jun' |
+| [' + + + - - + + ', ' + + + - + - - ', '++----+', '+++ --+ -', '+++-+ - -']	| 'start' |
+| [' + + - - - - + ', ' + + - + + - - ', '+ +-- +++ ', ' ++- ++++']	| 'algo' |
 
 ---
 
-## 입출력 설명
-  `+`는 `1`로, `-`는 `0`으로 변경되어 ' + - - + - + - '는 1001010이 됩니다. 이 숫자는 10진수로 74로 아스키코드로 바뀌었을 때 74로 아스키 코드표로 보면 대문자 J가 됩니다. 이와 같은 원리로 나머지 2개를 문자로 바꿔 조합하면 'Jun'이 됩니다.
+## Explanation
+The `+` becomes `1`, and the `-` becomes `0`, so ' + - - + - + - ' becomes 1001010. When this number is converted to decimal, it becomes 74. In the ASCII code table, 74 represents the uppercase letter J. By converting the other two strings in the same way and combining them, we get 'Jun.'
 
 ---
-
-## 스토리북 및 강의 소개
-
-"위니브 월드 : 새로운 시대" 스토리는 python 부트캠프, 눈떠보니 코딩테스트 전날, PyQt, Pygame, Save the Weniv World with Phaser로 이어지는 강의 스토리를 엮은 대서사시입니다. Notion 링크 [스토리 북](https://paullabworkspace.notion.site/08e6e80957d94459adeff743cbde9659)에서 읽어보실 수 있습니다. 
-
-- 해당 문제를 손코딩으로 2~3번 풀어보시길 권해드립니다.
-- 문제 해설 강의는 인프런에 런칭 예정입니다.
-- 문제집은 전자책과 PDF로 무료 배포 예정입니다.

--- a/src/pages/question10.md
+++ b/src/pages/question10.md
@@ -1,78 +1,75 @@
 - info
   - lv1
-  - 조합
+  - Combination
 
-# 알리는 포케가 좋아
-![알리의 포케 가게](./10_1.webp)
+# Ali's Poke Store
+![Ali's Poke Store](./10_1.webp)
 
-## 문제 설명
-개리가 스페이스 스톤을 사용하여 노역장에서 동족을 구하고 구출된 동족들은 자유를 얻었습니다. 노역장에서 데이터분석을 하던 알리는 평소 좋아하던 포케 가게를 열었습니다.
-친절한 알리는 손님이 원하는 토핑의 수와 꼭 들어가야 할 토핑을 말하면 만들 수 있는 모든 포케의 조합을 안내합니다.
+## Problem Description
+Ali, who used the Space Stone to save his tribe from slavery, has opened a Poke store that he has always liked. Kind Ali guides all possible combinations of Poke that can be made when customers tell the number of toppings they want and the toppings they want to include.
 
-포케에 넣을 수 있는 토핑은 아래와 같습니다.
+The toppings that can be put in Poke are as follows:
 
 ```text
-연어, 참치, 닭가슴살, 베이컨, 버섯
+Salmon, Tuna, Chicken, Bacon, Mushroom
 ```
 
-손님은 토핑을 최대 5개까지 고를 수 있으며, 꼭 들어가야 할 토핑도 고를 수 있습니다. 알리는 주문에 맞는 포케의 조합을 안내해야 합니다.
+Customers can choose up to 5 toppings, including toppings that must be included. Ali must guide the combination of Poke that matches the order.
 
-단, 아무것도 입력하지 않을 경우 `“기본 포케가 제공됩니다.”`라고 안내해야 합니다.
-
----
-
-## 제한 사항
-
-- 0 ≤ 토핑 수 ≤ 5
-- 토핑은 안내된 토핑 중 선택해야 합니다. (연어, 참치, 닭가슴살, 베이컨, 버섯)
+However, if nothing is entered, it must be informed that `"Basic Poke will be provided."`
 
 ---
 
-## 입출력 예
+## Constraints
 
-| 입력              | 출력                                                                                                                                                                                                                                                                       |
+- 0 ≤ Number of toppings ≤ 5
+- The toppings must be selected among `salmon, tuna, chicken, bacon, mushroom`.
+
+---
+
+## Input and Output Examples
+
+| Input              | Output                                                                                                                                                                                                                                                                       |
 | ----------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| []                | “기본 포케가 제공됩니다.”                                                                                                                                                                                                                                                  |
-| [2, “연어”]       | [["연어", "참치"], ["연어", "닭가슴살"], ["연어", "베이컨"], ["연어", "버섯"]]                                                                                                                                                                                             |
-| [3, “연어, 참치”] | [["연어", "참치", "닭가슴살"], ["연어", "참치", "베이컨"], ["연어", "참치", "버섯”]]                                                                                                                                                                                       |
-| [3, “”]           | [["연어", "참치", "닭가슴살"], ["연어", "참치", "베이컨"], ["연어", "참치", "버섯"], ["연어", "닭가슴살", "베이컨"], ["연어", "닭가슴살", "버섯"], ["연어", "베이컨", "버섯"], ["참치", "닭가슴살", "베이컨"], ["참치", "닭가슴살", "버섯"], ["닭고기", "베이컨", "버섯"]] |
+| []                | “Basic Poke will be provided.”                                                                                                                                                                                                                                                  |
+| [2, “salmon”]       | [["salmon", "tuna"], ["salmon", "chicken"], ["salmon", "bacon"], ["salmon", "mushroom"]]                                                                                                                                                                                             |
+| [3, “salmon, tuna”] | [["salmon", "tuna", "chicken"], ["salmon", "tuna", "bacon"], ["salmon", "tuna", "mushroom"]]                                                                                                                                                                                    |
+| [3, “”]           | [["salmon", "tuna", "chicken"], ["salmon", "tuna", "bacon"], ["salmon", "tuna", "mushroom"], ["salmon", "chicken", "bacon"], ["salmon", "chicken", "mushroom"], ["salmon", "bacon", "mushroom"], ["tuna", "chicken", "bacon"], ["tuna", "chicken", "mushroom"], ["chicken", "bacon", "mushroom"]] |
 
 ---
 
-## 입출력 설명
+## Explanation
 
-- 토핑의 수와 토핑을 입력받습니다.
-- 토핑의 수는 0부터 5까지 입력할 수 있습니다. 또한, 토핑은 안내된 토핑(연어, 참치, 닭가슴살, 베이컨, 버섯)에서 선택해야 하며, 문자열로 입력받습니다.
-- 토핑을 선택하지 않을 경우는 빈 문자열로 입력합니다.
-- 토핑의 조합은 배열로 출력합니다.
+- Enter the number of toppings and toppings.
+- The number of toppings can be entered from 0 to 5. In addition, toppings must be selected among sSalmon, tuna, chicken, bacon, mushroom and entered as a string.
+- If you do not choose toppings, enter an empty string.
+- The combination of toppings is output as an array.
 
 <br/>
 
-### 1. 아무것도 입력하지 않을 경우
+### 1. When nothing is entered
 
-아무것도 입력하지 않은 경우, 즉 빈 배열([])이 입력된 경우는 토핑의 수는 0개, 원하는 토핑은 없는 것으로 간주합니다. 따라서 **"기본 포케가 제공됩니다.”**가 출력됩니다.
+If nothing is entered, that is, if an empty array ([]) is entered, the number of toppings is considered to be 0 and there are no desired toppings. Therefore, `"Default Poke will be provided."` is output.
 <br/>
 
-### 2. 토핑의 수와 토핑 모두 입력된 경우
+### 2. When both the number of toppings and toppings are entered
 
-예를 들어 토핑의 수가 2, 꼭 들어가야 할 토핑으로 “연어”가 입력되었다면,
+For example, if the number of toppings is 2 and "salmon" is entered as a must-have topping,
 
-5개의 토핑 중 “연어”가 포함된 2개의 토핑을 선택해야 하므로 해당하는 모든 조합은 아래와 같습니다.
-
+Since you must choose 2 toppings that include "salmon" out of 5 toppings, all possible combinations that match are :
 ```text
-[["연어", "참치"], ["연어", "닭가슴살"], ["연어", "베이컨"], ["연어", "버섯"]]
+[["salmon", "tuna"], ["salmon", "chicken"], ["salmon", "bacon"], ["salmon", "mushroom"]]
 ```
 
 <br/>
 
-### 3. 토핑을 입력하지 않은 경우
+### 3. When no topping is entered
 
-예를 들어 토핑의 수로 3이 입력되었지만, 토핑은 입력되지 않는다면 
-5개의 토핑 중 필수로 포함하는 토핑 없이 3개를 선택해야 합니다. 그 조합은 아래와 같습니다.
+For example, if the number of toppings is entered as 3 but no topping is actually entered, then you must choose 3 toppings from the 5 available toppings without including any toppings that are required. The combinations are as follows.
 
 
 ```text
-[["연어", "참치", "닭가슴살"], ["연어", "참치", "베이컨"], ["연어", "참치", "버섯"],
-["연어", "닭가슴살", "베이컨"], ["연어", "닭가슴살", "버섯"], ["연어", "베이컨", "버섯"],
-["참치", "닭가슴살", "베이컨"], ["참치", "닭가슴살", "버섯"], ["닭고기", "베이컨", "버섯"]]
+[["salmon", "tuna", "chicken"], ["salmon", "tuna", "bacon"], ["salmon", "tuna", "mushroom"],
+["salmon", "chicken", "bacon"], ["salmon", "chicken", "mushroom"], ["salmon", "bacon", "mushroom"],
+["tuna", "chicken", "bacon"], ["tuna", "chicken", "mushroom"], ["chicken", "bacon", "mushroom"]]
 ```

--- a/src/pages/question2.md
+++ b/src/pages/question2.md
@@ -1,44 +1,45 @@
 - info
     - lv1
-    - 정규표현식
+    - Regular Expression
 
-# 암호문
-![7개의 원석을 발견한 동료](./2_1.webp)
+# Cipher Text
+![Colleagues who discovered seven stones](./2_1.webp)
 
-## 문제 설명
-라이캣은 신비의 섬 제주에서 7개의 원석을 확보하게 됩니다. 라이캣은 7개의 원석을 동료들에게 나눠주고, 라이언을 치기 위해 각자의 마을로 돌아가 힘을 모을 것을 당부합니다.
+## Problem Description
+Licat obtains 7 stones on the mysterious island of Jeju. Licat shares the 7 stones with his colleagues and urges them to return to their respective villages to gather strength to defeat Lion.
 
-![스톤을 부여받은 동료들](./2_2.webp)
+![Colleagues who received the stones](./2_2.webp)
 
-절대 스톤을 부여받은 동료들은 각각의 마을로 향합니다. 동료들은 먼 마을에서 고양이 마을로 돌아간 라이캣과 암호로 된 편지를 주고받습니다. 여러 가지 암호문 중, 최종 혁명(revolution) 날짜 암호문은 `월`과 `일`로 해독할 수 있습니다. 다음 규칙에 따라 편지에서 혁명의 날짜를 알아내 출정 준비를 하세요.
+The colleagues who received the stones head back to their respective villages. They exchange letters with Licat, who has returned to the cat village, using a cipher. Among various cipher texts, the final revolutionary date can be deciphered by the month and day. Please prepare for the expedition by finding out the date of the revolution in the letter according to the following rules:
 
-- 편지 안에 내용은 문자열로 주어집니다.
-- 문자열 중에 r, e, v 뒤에 나오는 값을 더하여 나온 최종 숫자에서 앞자리를 `월`로 뒷자리를 `일`로 판단합니다.
-- r, e, v 뒤에 나오는 숫자는 1부터 10까지입니다. 이를 넘어가는 숫자가 나올 경우 앞 숫자만 뽑아냅니다.
+- The content of the letter is given as a string.
+- The date of the revolution is determined by considering the number obtained by adding the values after r, e, and v in the string. The digit before the tens place is considered the `month` and the digit in the ones place is considered the `day`.
+- The numbers after r, e, and v are between 1 and 10. If a number greater than 10 appears, only the digit in the ones place is considered.
 
----
-
-## 제한 사항
-
-- 1 ≤ r, e, v 뒤의 숫자 ≤ 10
-- 11 ≤ 합한 값 ≤ 99
 
 ---
 
-## 입출력 예
+## Constraints
 
-| 입력                                  | 출력  |
+- 1 ≤ the number after r, e, and v ≤ 10
+- 11 ≤ the sum of the numbers ≤ 99
+
+---
+
+## Input and Output Examples
+
+| Input                                  | Output  |
 | ---------------------------------------- | ------- |
 | 'a10b9r1ce33uab8wc918v2cv11v9'          | ['1월 6일'] |
 
 ---
 
-## 입출력 설명
+## Explanation
 
-패턴에 맞게 뽑아낸 값은 아래와 같습니다. e33은 e3으로 인식해서 3만 뽑아내야 합니다.
+The extracted values from the string according to the pattern are as follows. e33 should be recognized as e3, and only 3 should be extracted.
 
 ```py
 ['r1', 'e3', 'v2', 'v1', 'v9']
 ```
 
-이 숫자를 모두 더하면 `16`으로 앞자리가 월, 뒷자리가 일이 됩니다. 혁명의 날짜는 `1월 6일`입니다.
+When all these numbers are added together, the result is `16`, which means the digit before the tens place is the month and the digit in the ones place is the day. Therefore, the date of the revolution is `January 6th`.

--- a/src/pages/question3.md
+++ b/src/pages/question3.md
@@ -1,50 +1,54 @@
 - info
     - lv1
-    - 정렬
+    - Sorting
 
-# 출정인원 선발
-![연설하는 자바독](./3_1.webp)
+# Selecting Personnel for Expedition
+![Javadog giving a speech](./3_1.webp)
 
-## 문제 설명
-자바독은 마을로 돌아왔습니다. 마을은 일할 수 있는 청장년들이 모두 차출되어 어린이와 청소년만 남아있는 기이한 풍경이었습니다. 자바독은 각 부족에 전서를 보내 라이언에게 충성하며 각종 험난한 SI 작업에 끌려다녀 수십 년간 제대로 된 식사 한 번 못 했던 특급 기술자들을 불러 모읍니다. 그리고 묵묵히 정성스레 저녁 식사를 대접합니다. 횟수가 반복될수록 특급기술자들의 마음이 열리게 되었습니다.
+## Problem Description
+Javadog has returned to the village. The village looks strange with only children and teenagers remaining, as all the capable young men have been called away to various SI tasks and cannot be spared. Javadog brings in the special engineers who have never had a decent meal for decades, being dragged around by various hazardous SI tasks, to prepare a lavish dinner for them. As the number of dinners increases, the hearts of the special engineers open up.
 
-자바독이 가진 스톤은 마인드 스톤! 자바독은 마인드 스톤을 통해 혁명이 일어난 후 30년, 50년 후 그들의 노후를 보여줬어요. 그리고 다음 자녀들의 미래를요.
+Javadog's stone is the Mind Stone! Through the Mind Stone, Javadog showed the aging of those who had undergone a revolution 30 to 50 years ago, and the future of their next generation.
 
-" 우리의 미래가 아니라, 우리 자녀들의 미래를 위해서!
+" Not for our future, but the future of our children!
 
-자바독은 능력자를 선별했습니다. 이미 고도로 단련된 특급 기술자! 그러나 희생을 최소화하기 위해 시험을 보기로 했습니다. 시험을 본 인원에 상위 30%만 전투에 참가하기로 결정했어요.
+Javadog selected talented individuals. Already highly trained special engineers! However, to minimize sacrifices, they decided to take an exam. Only the top 30% of those who took the exam would be selected for the expedition.
 
-" 아무도 나오지 않는다면, 아무도 출정하지 않는다독!
+
+" If no one comes out, no one will go out!
 
 ```py
 army = [['A', 25, 24, 11, 12], ['B', 13, 22, 16, 14]]
 ```
 
-각 입력값은 `이름, 체력, 정신력, 기술력, 방어력`으로 주어집니다. 위와 같이 만약 2명만 지원한다면 30%를 선발할 수 없기에 아무도 출정하지 않습니다. 만약 4명이 지원을 하였고 모두가 점수가 다르다면 단 한 명만 출정할 수 있어요. 30%에 해당하는 기술자의 이름을 return하는 solution 함수를 완성하세요. 
+Each input value is given in the form of `name, health, mentality, skill, defense`. If only two people apply as shown above, 30% cannot be selected, so no one will go out. If four people apply and all have different scores, only one person can go out. Complete the solution function to return the name of the technician corresponding to the 30% selection criteria.
+
+
 
 ---
 
-## 제한 사항
+## Constraints
 
-- 0 ≤ 체력, 정신력, 기술력, 방어력 ≤ 25
-- 1 ≤ 기술자 수 ≤ 10
-- 기술자 배열은 2차원 배열로 주어집니다.
-- 기술자 이름은 중복되지 않습니다.
-- 동점자가 여러명 있을 경우 한 명으로 취급합니다.
+- 0 ≤ health, mentality, skill, defense ≤ 25
+- 1 ≤ number of technicians ≤ 10
+- The technician array is given as a two-dimensional array.
+- Technician names are not duplicated.
+- In case of a tie, only one person is considered.
 
 ---
 
-## 입출력 예
+## Input and Output Examples
 
-|          입력         |  출력 |
+|          Input         |  Output |
 | ------------------------ | ------- |
 | [['A', 25, 24, 11, 12], ['B', 13, 22, 16, 14]] | [] |
 | [['A', 25, 25, 25, 25], ['B', 10, 12, 13, 11], ['C', 24, 22, 23, 21], ['D', 13, 22, 16, 14]] | ['A'] |
 
 ---
 
-## 입출력 설명
-- 기술자의 이름, 체력, 정신력, 기술력, 방어력이 담긴 배열을 입력받습니다.
-- 체력, 정신력, 기술력, 방어력의 총합을 구했을 때 상위 30%의 지원자만 전투에 참가할 수 있습니다.
-- 기술자의 이름은 점수의 내림차순으로 출력합니다.
-- 동일한 점수의 기술자가 있을 경우 알파벳의 역순으로 출력합니다.
+## Explanation
+
+- An array containing the names, health, mentality, skill, and defense of the technicians is given as input.
+- Only the top 30% of applicants can participate in the expedition when the sum of health, mentality, skill, and defense is calculated.
+- The names of the technicians are sorted in descending order of score.
+- If there are technicians with the same score, they are sorted in reverse alphabetical order.

--- a/src/pages/question4.md
+++ b/src/pages/question4.md
@@ -1,58 +1,59 @@
 - info
     - lv1
-    - 정규표현식
+    - Regular Expression
 
-# 꿈의 설계
-![리얼스톤을 가진 빙키](./4_1.webp)
+# Dream Design
+![Binky with Real Stone](./4_1.webp)
 
-## 문제 설명
-리얼스톤을 가진 빙키는 현실과 같은 허상을 만들어낼 수 있게 되었습니다. 빙키는 이 허상을 통해 바꿀 수 있는 미래를 보여주기로 했어요. 주도적으로, 주체적으로 사는 이들이 얼마나 많은 것을 이룰 수 있는지요.
+## Problem Description
+Binky who has the Real Stone, can create a fantasy world just like the reality. Through this fantasy world, Binky shows how much those who live autonomously and independently can achieve.
 
-본 것을 이룰 수 있는지는 리얼 스톤이 해줄 수 있는 일은 아니었지만, 적어도 절망이 뿌리 깊이 내린 위니브 월드 안에 한 줄기 빛이 될 수는 있을 겁니다.
+Although the Real Stone cannot help you achieve what you see, it can at least become a ray of hope in the desperate Winnieb World.
 
 ```py
-['빙키는 10만큼 A를 훈련했다. 빙키는 날씨가 안 좋은데도 불구하고 20만큼 B를 했다. 빙키는 비가 내리는 가운데서도 10만큼 B를 훈련했다.', '빙키는 A를 30만큼 고민했다. 40만큼 B를 고민했다. 빙키는 A를 70만큼 참 오랜 시간 고민했다. 빙키는 놀랍게도 C를 10만큼 고민했다.']
+['Binky trained 10 times A. Binky trained 20 times B even though the weather was bad. Binky trained 10 times B while it was raining. ',
+'Binky thought 30 about A. Binky thought 40 about B. Binky spent a surprisingly long time, 70, thinking about A. Binky also thought 10 about C.']
 ```
 
-첫 번째 문자열에서 숫자를 모두 추출합니다. A를 훈련한 수치는 10, B를 훈련한 수치는 30입니다. 두 번째 문자열에서도 숫자를 추출합니다. A를 고민한 수치는 100, B를 고민한 수치는 40입니다. C를 고민한 수치는 10입니다. 이 수치를 `훈련수치 X 고민수치`로 계산합니다. C는 훈련하지 않았기 때문에 사라집니다.
+Extract all the numbers from the first string. The number of times A was trained is 10 and the number of times B was trained is 30. Extract numbers from the second string. The number of times A was thought about is 100, the number of times B was thought about is 40, and the number of times C was thought about is 10. Calculate this value as `training value X consideration value`. C disappears because it was not trained.
 
+Original future: When multiplying the number of times A was trained by the number of times A was thought about, the result is 1000. When multiplying the number of times B was trained by the number of times B was thought about, the result is 1200. Adding these values together gives the original future.
 
-원래 미래 : A를 훈련한 수치와 A를 고민한 수치를 곱하면 1000이 나옵니다. B를 훈련한 수치와 B를 고민한 수치를 곱하면 1200이 나옵니다. 이를 더하면 원래 미래가 나옵니다.
+Changed future: Add 100 to the value that was trained the most. Add 100 to the value that was thought about the most. Therefore, the number of times B was trained becomes 130 and the number of times A was thought about becomes 200. Finally, since the number of times A was trained is 10 and the number of times A was thought about is 200, the result is 2000, and the number of times B was trained is 130, and the number of times B was thought about is multiplied by 40 to become 5200.
 
-
-바뀐 미래 : 가장 많이 훈련한 수치에 100을 더합니다. 가장 많이 고민한 수치에 100을 더합니다. 따라서 B를 훈련한 수치는 130이 되고, A를 고민한 수치는 200이 됩니다. 최종적으로 A를 훈련한 수치는 10, A를 고민한 수치는 200이 되므로 2000 값이 되고, B를 훈련한 수치는 130에 B를 고민한 수치 40을 곱하여 5200이 됩니다.
-
-결괏값은 아래와 같이 출력됩니다.
+The result is as follows.
 
 ```py
-'최종 꿈의 설계는 원래 미래 2000, 바뀐 미래 5200입니다. 이 수치대로 Vision을 만듭니다.'
+
+'The final dream design is 2000 for the original future and 5200 for the changed future. We will create Vision according to this value.'
+
 ```
 
 ---
 
-## 제한 사항
+## Constraints
 
-- 입력 배열의 길이는 2입니다. [훈련수치, 고민수치]의 형태로 문자열이 입력됩니다.
-- 수치 문자열은 항상 마침표 단위로 문장이 나뉩니다. 나누어진 문장을 나뉜 문장이라고 했을 때 나뉜 문장에는 항상 유일한 수치와 유일한 알파벳이 있습니다.
-- 매칭되는 고민 수치와 훈련 수치가 없을 경우에는 ‘미래가 보이지 않습니다.’라고 출력해야 합니다.
-- 1 ≤ 나뉜 문장  ≤ 10
-- 1 ≤ 수치 ≤ 1000
-- A ≤ 알파벳 ≤ z
+- The length of the input array is 2. Strings are entered in the form of [training value, consideration value].
+- Numeric strings are always sentence-separated by a period. If a divided sentence is called a split sentence, there is always a unique number and a unique alphabet in the split sentence.
+- If there is no matching consideration value or training value, "The future is not visible." should be output.
+- 1 ≤ the number of split sentences ≤ 10
+- 1 ≤ numeric value ≤ 1000
+- A ≤ alphabet ≤ z
 
 ---
 
-## 입출력 예
+## Input and Output Examples
 
-| 입력                                  | 출력  |
+| Input                                  | Output  |
 | ---------------------------------------- | ------- |
-| ['100만큼 A를 훈련. 201 B.  120보다 이십만큼 더 B를 훈련했다.', '30만큼 A를 고민했다. 40만큼 B를 고민. 빙키는 A를 70만큼. C 10. D 10. A 10. z 10.'] | 최종 꿈의 설계는 원래 미래 23840, 바뀐 미래 37840입니다. 이 수치대로 Vision을 만듭니다. |
+| ['Trained A for 100. 201 for B. Trained B 20 more than 120.', 'Contemplated A for 30. Contemplated B for 40. Puzzled over A for 70. C 10. D 10. A 10. z 10.'] | The final design for the dream is original future 23840, changed future 37840. We create Vision according to these numbers. |
 
 ---
 
-## 입출력 설명
+## Explanation
 
-- 훈련수치는 A는 100, B는 321입니다. B를 더 많이 훈련하였으므로 B에 100을 더해 421이 됩니다.
-- 고민수치는 A는 110, B는 40입니다. 나머지는 훈련수치와 짝이 맞는 것이 없으므로 무시됩니다. A를 더 많이 고민했으므로 A에 100을 더하여 210이 됩니다.
-- (100 * 110) + (321 * 40)을 연산하여 원래 미래는 23840 값이 나옵니다.
-- (100 * 210) + (421 * 40)을 연산하여 바뀐 미래는 37840 값이 나옵니다.
-- 이 결과를 바탕으로 '최종 꿈의 설계는 원래 미래 23840, 바뀐 미래 37840입니다. 이 수치대로 Vision을 만듭니다.'라는 텍스트를 만듭니다. 콤마는 찍지 않습니다.
+- The training values are 100 for A and 321 for B. Since B was trained more, adding 100 to B makes it 421.
+- The contemplation values are 110 for A and 40 for B. The rest are ignored as they do not match the training values. Since A contemplated more, adding 100 to A makes it 210.
+- Computing (100 * 110) + (321 * 40) results in the original future value of 23840.
+- Computing (100 * 210) + (421 * 40) results in the changed future value of 37840.
+- Based on these results, create the text "The final design of the dream is an original future of 23840 and a changed future of 37840. Create the Vision based on these values." Do not include a comma.

--- a/src/pages/question5.md
+++ b/src/pages/question5.md
@@ -1,25 +1,25 @@
 - info
     - lv1
-    - 행렬
+    - Matrix
 
-# 상한 당근 찾기
-![빙키의 당근밭](./5_1.webp)
+# Finding a Rotten Carrot
+![Binky's carrot farm](./5_1.webp)
 
-## 문제 설명
-빙키의 능력으로 무엇을 할 수 있는지 희망을 본 사람들에게 실제로 바꿀 수 있는 고향의 모습을 보여주었습니다. 이제는 더 이상 Vision의 영역이 아니었습니다. Action의 영역이었죠!
+## Problem Description
+Binky showed people the appearance of their hometowns that could be changed by his power. It was no longer just a Vision, it was an Action!
 
-고향은 많이 변해있었습니다. 산업화가 닥친 마을은 동산이 모두 없어지고, 온통 높은 건물들뿐이었어요. 사람들은 평안을 잃었고, 어디서나 놀고 잘 수 있었던 마을은 사라졌습니다. 이제 돈 없이는 무엇도 마음대로 먹을 수 없었죠. 그리하여 나누지도 않게 되었습니다.
+The hometown has changed a lot. The town that faced industrialization had no orchards left, only tall buildings. People lost their peace and the village where they could play and rest anywhere disappeared. Without money, they could not eat what they wanted. So they became divided.
 
-빙키는 밭부터 일구기로 합니다. 가장 기초적인 의식주 회복으로 평안을 회복하고자 합니다.
+Binky starts with the field. He wants to restore peace through the most basic food recovery.
 
-" 내가 변화시킬 수 있는 일부터! 우리가 변화시킬 수 있는 일부터!
+" From what I can change! From what we can change!
 
-1. 당근밭은 N X M개의 칸으로 이루어져 있습니다. (N: 행, M: 열) 
-2. 상한 당근은 `#`으로 표현되어 있습니다.
-3. 현재 당근밭에는 상한 당근만 남아있으며, 일부 칸은 비어있습니다. 빙키는 인력의 효율적인 배치를 위해 `상한 당근의 개수`와 `인접 상한 당근의 통계`를 내기로 했습니다. 반환 값은 `상한 당근`의 개수와 `비어있는 칸과 맞닿은 둘레에 위치한 상한 당근의 개수 총합`을 작성해야 합니다.
-4. 맞닿은 둘레에 위치한 칸은 최대 8개로, 상, 하, 좌, 우, 4개의 대각선 칸을 말합니다.
+1. The carrot field consists of N x M cells. (N: rows, M: columns)
+2. Spoiled carrots are represented by `#`.
+3. There are only spoiled carrots left in the carrot field, and some cells are empty. Binky decided to give the `number of spoiled carrots` and the `number of adjacent spoiled carrots` on the empty cell for efficient placement of labor. You need to write the total number of spoiled carrots and the number of spoiled carrots located on the empty cell and adjacent to the edge.
+4.Cells located on the edge have a maximum of 8 adjacent cells, which refer to cells in four directions, up, down, left, and right, and four diagonal cells.
 
-아래 표를 당근밭이라고 했을 때, A2의 둘레에 위치한 칸은 A1, B1, B2, B3, A3이며, A2에 작성해야 할 상한 당근의 개수는 2가 됩니다. 여기서 #은 상한 당근이 위치했음을 나타냅니다.
+If you say the table below is a carrot field, the cells around A2 are A1, B1, B2, B3, A3, and the number of spoiled carrots to be written in A2 is 2. Here, `#` indicates that the spoiled carrot is located.
 
 <br />
 
@@ -39,7 +39,7 @@
 
 <br />
 
-모든 비어있는 칸에 상한 당근의 개수를 작성하면 아래와 같으며, 개수를 모두 합한 결괏값은 10이 나옵니다.
+If you write the number of spoiled carrots in all empty cells, the result is as follows, and the sum of the number is 10.
 
 <br />
 
@@ -51,17 +51,17 @@
 
 ---
 
-## 제한 사항
+## Constraints
 
 - 1 ≤ N, M ≤ 100
-- 당근밭은 2차원 배열로 주어집니다.
-- 0은 비어있는 칸을, ‘#’은 상한 당근을 뜻합니다.
+- The carrot field is given as a two-dimensional array.
+- 0 indicates an empty cell, and `#` indicates a spoiled carrot.
 
 ---
 
-## 입출력 예
+## Input and Output Examples
 
-| 입력 | 출력 |
+| Input | Output |
 | --- | --- |
 | [[0, ‘#’], [0, 0]] | [1, 3] |
 | [[0, 0, ‘#’, ‘#’], [’#’, ‘#’, 0, ‘#’], [0, ‘#’, ‘#’, 0]] | [7, 16] |
@@ -69,7 +69,8 @@
 
 ---
 
-## 입출력 설명
-- 2차원 배열로 이루어진 당근밭이 입력됩니다. 상한 당근의 개수와 비어있는 값을 둘레에 위치한 상한 당근의 개수로 모두 채운 후 개수의 모든 합을 결과로 출력합니다.
-- 예를 들어, `[[0, ‘#’], [0, 0]]`이 입력되었을 경우 상한 당근의 개수가 입력되어야 할 비어있는 칸은 (0, 0), (1, 0), (1, 1)입니다. 
-- 여기서 각 둘레에 위치한 상한 당근의 개수는 1개로 동일합니다. 개수가 입력된 배열은 `[[1, ‘#’], [1, 1]]`이며, 총합은 3이 출력됩니다. 따라서 반환값은 `[1, 3]`이 됩니다.
+## Explanation
+
+- A carrot field consisting of a two-dimensional array is input. After filling in the maximum number of spoiled carrots and empty values with the number of spoiled carrots located on the perimeter, the sum of all numbers is output as the result.
+- For example, if `[[0, ‘#’], [0, 0]]` is input, the empty spaces where the maximum number of spoiled carrots should be entered are (0, 0), (1, 0), and (1, 1).
+- Here, the number of spoiled carrots located on each perimeter is the same, with one each. The array with the numbers entered is `[[1, ‘#’], [1, 1]]`, and the total sum is 3. Therefore, the return value is `[1, 3]`.

--- a/src/pages/question6.md
+++ b/src/pages/question6.md
@@ -1,43 +1,41 @@
 - info
     - lv1
-    - 스택 | 큐
+    - Stack | Queue
 
-# 샌드위치 포장
-![직원 수 1만 명이 된 캣네 생선](./6_1.webp)
+# Sandwich Packaging
+![Catfish Inc. with 10,000 employees](./6_1.webp)
 
-## 문제 설명
-라이캣도 혁명을 준비하기 위해 고향으로 내려왔습니다. 라이캣이 원석을 구하러 떠나기 전 설립했던 캣네 생선은 직원 수 20명에서 1만 명이 되었습니다. 
-라이캣은 돌아온 사실을 누구에게도 알리지 않고 도시를 돌아다녔습니다. (주)캣네생선을 중심으로 이룬 큰 경제 성장에도 여전히 그늘진 곳이 보였습니다. 여전히 없는 사람은 병원에 가지 못했고, 누군가는 구걸을 하고 있었으며, 없는 사람은 더욱더 많이 라이언 타운의 강제 노역에 끌려가야 했습니다. 고양이가 아무리 많다 하더라도, 결국 사자를 이길 수는 없었으니까요. 큰 경제 성장을 이룬 만큼 더욱 핍박받고, 약탈당했으며, 위협받았습니다.
-라이캣은 라이언 타운의 강제 노역에 끌려갔다 돌아온 사람들이 모여있는 마을에 정착합니다. 그들은 성치 않은 마음과 정신으로 더 이상 무엇에도 도움이 안 되기에 누구도 신경 쓰지 않았고, 서로가 서로를 위로해 주며 마을을 이뤘습니다.
+## Problem Description
+Licat has come down to his hometown to prepare for a revolution. Catfish, which he established before leaving to get the original stone, has grown from 20 employees to 10,000. Licat traveled around the city without telling anyone about his return. Despite the large economic growth centered around Catfish Inc., there were still shady areas. Some people could not go to the hospital, some were begging, and more and more people were forced into forced labor in Lion Town, even with many cats, they could not beat the lions. They were persecuted, looted, and threatened more as they achieved significant economic growth.
 
+Licat settles in the village where people who returned from Lion Town gathered. They had become useless in mind and spirit, and no one cared about them, so they comforted each other and built a village.
 
-라이캣은 여기에 무료 샌드위치 급식소를 차렸습니다. 누구에게 시키지 않고 직접 포장 업무를 맡았습니다. 라이캣은 아침 일찍 일어나 재료를 준비했습니다. 다만 마을에서 구할 수 있는 것이 한계가 있어 주변 마을로부터 되는대로 재료를 준비했습니다. 재료가 준비되면 `식빵 → 계란 → 베이컨 → 야채 → 식빵`과 같은 조리 순서로 항상 순서에 맞게 샌드위치를 하나씩 정성스럽게 포장했습니다. 그가 가진 스톤이 빛을 발했습니다.
+Licat set up a free sandwich cafeteria here and took care of the packaging work without asking anyone. Licat got up early in the morning and prepared the ingredients. However, since there was a limit to what could be obtained from the village, he prepared the ingredients from the surrounding villages. Once the ingredients were ready, he packaged one sandwich at a time in the order of cooking, such as `bread → egg → bacon → vegetables → bread`. His stone shone.
 
+1. When the ingredients come in the order of [bread, bread, egg, bacon, vegetable, bread, egg, bacon, vegetable, bread],
+2. You can package one sandwich from the second to sixth ingredients.
+3. Now, you can package one sandwich with the first ingredient and the seventh to tenth ingredients.
+4. Therefore, a total of two sandwiches can be made. Sandwiches cannot be packaged if the order is reversed.
 
-1. 재료의 순서로 [식빵, 식빵, 계란, 베이컨, 야채, 식빵, 계란, 베이컨, 야채, 식빵] 이 들어온 경우 
-2. 2번째부터 6번째까지의 재료로 샌드위치 한 개를 포장할 수 있습니다.
-3. 이제 1번째 재료와 7번째부터 10번째까지의 재료로 하나의 샌드위치를 포장할 수 있습니다. 
-4. 그러므로, 총 2개의 샌드위치를 만들어 낼 수 있습니다. 순서가 바뀌면 샌드위치는 포장할 수 없습니다.
-
-위의 예제와 같이 라이캣에게 전해지는 재료의 정보가 리스트로 주어졌을 때, 포장할 수 있는 샌드위치 개수를 출력하세요.
+Given the information of the ingredients that Licat receives in a list, output the number of sandwiches that can be packaged.
 
 ---
 
-## 제한 사항
+## Constraints
 
-- 1 ≤ 재료의 길이 ≤ 1,000,000
-- 재료의 종류는 다음과 같이 나타냅니다.
-  - 1 : 식빵
-  - 2 : 계란
-  - 3 : 야채
-  - 4 : 베이컨
-- 정답은 오로지 하나만 존재합니다.
+- 1 ≤ the length of the ingredients ≤ 1,000,000
+- The ingredients are represented as follows:
+  - 1: bread
+  - 2: egg
+  - 3: vegetable
+  - 4: bacon
+- There is only one correct answer.
 
 ---
 
-## 입출력 예
+## Input and Output Examples
 
-| 입력                                | 출력  |
+| Input                                | Output  |
 | ---------------------------------------- | ------- |
 | [1, 2, 3, 4, 1, 1, 2, 3, 4] | 1 |
 | [1, 1, 1, 2, 3, 4, 2, 3, 4, 1] | 2 |
@@ -46,10 +44,9 @@
 
 ---
 
-## 입출력 설명
-- 숫자로 된 리스트를 입력받습니다.
-- 샌드위치의 순서는 항상 1, 2, 3, 4, 1을 지켜야 합니다.
-- 재료는 순서를 바꿔 중간에서 빼내지 못합니다. 오로지 완성된 샌드위치만 입력 배열에서 빠질 수 있습니다.
-- 리스트 내에서 샌드위치가 만들어질 수 있는 개수를 결괏값으로 출력합니다.
+## Explanation
 
-
+- A list of numbers is inputted.
+- The order of the sandwich must always follow 1, 2, 3, 4, 1.
+- The ingredients cannot be taken out in the middle by changing the order. Only completed sandwiches can be removed from the input list.
+- The number of sandwiches that can be made from the list is outputted as the result.

--- a/src/pages/question7.md
+++ b/src/pages/question7.md
@@ -1,39 +1,37 @@
 - info
     - lv1
-    - 투포인터 | 슬라이딩 윈도우
+    - Two Pointers | Sliding Window
 
-# 두 수의 합 찾기
-![북극의 광산을 찾아온 소울곰](./7_1.webp)
+# Sum of Two Numbers
+![SoulGom visits a mine in the Arctic](./7_1.webp)
 
-## 문제 설명
-소울곰은 고향이 있지 않았어요. 그는 파이와 썬이 만든 NPC였기 때문이죠! 하지만 소울 스톤을 받음으로써 그에게도 영혼이 생겼습니다. 더불어 큰 지혜와 영혼 세계를 볼 수 있게 되었죠.
+## Problem Description
+SoulGom had no hometown. He was an NPC created by Pye and Sun! But by receiving a soul stone, he gained a soul, as well as great wisdom and the ability to see the world of souls.
 
-소울곰은 생각했어요.
+SoulGom thought to himself, 
 
-" 지금 내가 어떤 도움을?
+" What can I do to help?
 
-소울곰은 소울 스톤을 통해 알게 된 지혜로 곧 막대한 전쟁자금이 필요할 것이라는 것을 예측할 수 있었어요. 
-소울곰은 북극으로 향했습니다. 생명체는 살아남을 수 없는 극한의 냉기. 그의 몸은 생명체가 아니었기에 자유롭게 움직일 수 있었어요. 더 깊은 곳으로 향했습니다. 누구의 손길도 닿지 않은 그곳, 태고의 보물이 있는 곳으로요. 
+Through the wisdom he gained from the soul stone, SoulGom was able to predict that he would soon need a huge amount of war funds. He headed for the Arctic. It is a place where no living creatures can survive due to extreme cold. Because his body was not that of a living creature, he could move around freely. He went deeper into the area, to the place where the ancient treasure was hidden, untouched by anyone's hand.
 
-그곳에는 어마어마한 양의 보석들이 숨겨져 있었어요. 세상의 모든 보화를 합친 것보다 많은 보화가요. 전쟁이 나면 화폐가치는 한없이 떨어질 것이고, 초인플레이션이 위니브 월드를 덮을 것이며, 그렇기에 보석의 가치는 더욱 빛나겠다고 생각했어요. 보석을 본 소울곰은 희미하게 웃었습니다. 
+There were a tremendous amount of jewels hidden there, more than all the world's wealth combined. SoulGom thought that if war broke out, the value of money would plummet infinitely, hyperinflation would engulf Winnieb World, and so the value of jewels would shine even more brightly. As he looked at the jewels, SoulGom smiled faintly.
 
-믿음, 보람, 역할, 존재의 이유, 혁신과 혁명, 카르텔 등 소울곰은 곡괭이를 휘두르면서도 그동안 단순한 단어로만 머리에 저장되어 있던 세상에 많은 지식들을 곱씹고, 지혜와 영혼으로 승화시켰어요.
+Faith, worth, role, reason for existence, innovation and revolution, cartels, and more. As he swung his pickaxe, SoulGom mulled over many pieces of knowledge that had only been stored in his head as simple words until now, and transformed them into wisdom and soul.
 
-소울곰은 광차를 만들어 더욱 많은 양의 보석을 움직일 수 있게 되었습니다. 광차에는 실을 수 있는 중량이 있고, 최대 2개밖에 나르지 못합니다.
-보석들의 중량이 주어졌을 때 특정 보석 2개를 합쳐 광차 중량을 맞출 수 있는 보석을 찾아주세요.
+SoulGom made a mining cart and was able to move even more jewels. The mining cart has a weight capacity and can only carry up to two items at a time. Please find the two jewels that can be combined to match the weight of the mining cart, given the weight of each jewel.
 
 ---
 
-## 제한 사항
+## Constraints
 
-- 2 ≤ 리스트 길이 ≤ 99
-- 정답은 오로지 하나만 존재합니다.
+- 2 ≤ length of list ≤ 99
+- There is only one correct answer.
 
 ---
 
-## 입출력 예
+## Input and Output Examples
 
-| 보석 중량 리스트                          | 광차 중량  |  출력  |
+| Weight of Jewels List                        | Weight of Mining Cart  |  Output  |
 | ---------------------------------------- | ------- |------- |
 | [4, 9, 11, 2] | 6 | [0, 3] |
 | [2, 2] | 4 | [0, 1] |
@@ -42,7 +40,8 @@
 
 ---
 
-## 입출력 설명
-- 정답이 없는 경우는 없습니다.
-- 숫자로 된 보석 중량 리스트 중 항상 2개를 더하여 광차 중량에 맞춰야 합니다.
-- 2개 보석의 인덱스 값을 결괏값으로 출력합니다.
+## Explanation
+
+- There are no cases where there is no answer.
+- When adding up two jewel weights from the list of weights that are numeric, it must always match the weight of the mining cart.
+- The index values of the two jewels should be output as the result.

--- a/src/pages/question8.md
+++ b/src/pages/question8.md
@@ -1,27 +1,27 @@
 - info
     - lv0
-    - 수학
+    - Math
 
-# 무기 생산
-![대장간에서 무기를 사려는 개리](./8_1.webp)
+# Weapon Production
+![Gary buying weapons in the forge](./8_1.webp)
 
-## 문제 설명
-개리는 북극에 소울곰의 보석을 받아 돈으로 환전하여 무기를 준비하는 일을 하고 있습니다. 개리가 의뢰하는 대장간은 검 1자루에 3000원, 날카롭게 날을 세우면 300원이 추가됩니다. 단골이라 검 10자루당 날이 서지 않은 검 1자루, 100자루당 날이 선 검 1자루가 제공됩니다.
+## Problem Description
+Gary is preparing to buy weapons by exchanging the jewels of the soul bears he received in the Arctic for money. The blacksmith Gary is requesting offers swords for 3000 won per piece, and if he sharpens the blade, an additional 300 won is added. As a regular customer, one unsheathed sword is provided for every 10 swords, and one sharpened sword is provided for every 100 swords.
 
-무기 구매 예산이 주어졌을 때 개리가 구할 수 있는 날이 선 검은 몇 자루일까요?
-
----
-
-## 제한 사항
-
-- 무기 구매 예산은 항상 양수이며 100원 단위로 주어집니다.
-- 100 ≤ 무기 구매 예산 ≤ 1000000
+If the budget for buying weapons is given, how many sharpened swords can Gary buy?
 
 ---
 
-## 입출력 예
+## Constraints
 
-| 입력                                  | 출력  |
+- The budget for buying weapons is always a positive integer and given in multiples of 100.
+- 100 ≤ Budget  ≤ 1000000
+
+---
+
+## Input and Output Examples
+
+| Input                                  | Output  |
 | ---------------------------------------- | ------- |
 | 100 | 0 |
 | 36000 | 12 |
@@ -29,8 +29,8 @@
 
 ---
 
-## 입출력 설명
+## Explanation
 
-- 예산이 100원이면 검을 0자루 구매할 수 있습니다.
-- 예산이 36000원이면 3300원 * 11자루 + (서비스*1자루 + 300) = 33300원으로 날이 선 검 12자루 구매할 수 있습니다.
-- 예산이 66600원이면 3300 * 22자루 + (서비스*2자루 + 300*2) = 66600원으로 24자루 구매할 수 있습니다.
+- If the budget is 100 won, Gary can buy 0 swords.
+- If the budget is 36000 won, Gary can buy 12 sharpened swords with 11 unsheathed swords for 3300 won each plus one sharpened sword as a service and an additional 300 won.
+- If the budget is 66600 won, Gary can buy 24 sharpened swords with 22 unsheathed swords for 3300 won each plus two sharpened swords as a service and an additional 600 won.

--- a/src/pages/question9.md
+++ b/src/pages/question9.md
@@ -1,21 +1,21 @@
 - info
     - lv1
-    - 투포인터 | 슬라이딩 윈도우
+    - Two Pointers | Sliding Window
 
-# 최대 손실액
-![그래프 차트](./9_2.webp)
+# Maximum Loss Amount
+![Graph Chart](./9_2.webp)
 
-## 문제 설명
-‘캣네 생선’ 대표인 대리인 No.1 는 지난 1년간의 그래프 변동을 보고 Risk 관리를 위해 발생할 수 있는 최악의 손실액을 구하고 싶었습니다. 그래프 차트가 주어졌을 때 발생할 수 있는 `최악의 손실액`을 구해봅니다.
+## Problem Description
+Representative No. 1 of "Catfish Inc." wanted to calculate the worst possible loss amount that could occur for risk management after looking at the graph changes for the past year. Let's find out the `worst possible loss amount` that can occur when given a graph chart.
 
-위 그래프에서 최고가(61,100)에 사서 최저가(52,700)에 팔면 최대 손실이 발생할 것 같지만 최고가 입장에서 최저가는 이미 지난 시간이기 때문에 팔 수 없는 지난 가격이 됩니다. 
+In the above graph, buying at the highest price (61,100) and selling at the lowest price (52,700) seems to incur the maximum loss. However, from the perspective of the highest price, the lowest price is already in the past, so it becomes a meaningless past price that cannot be sold.
 
 <br/>
 
-입력값이 58000, 58700, 55300, 54200, 53600, 52700, 57700, 61100 순서대로 들어온다고 생각해보겠습니다. 시간 순서에 따라 각 구간의 최대 손실을 계산해보겠습니다. 
+Let's assume that input values are entered in the order of 58,000, 58,700, 55,300, 54,200, 53,600, 52,700, 57,700, 61,100. Let's calculate the maximum loss of each interval according to the time order.
 
 
-| Day | 입력 | 최고가 | 최저가 | 최대손실액 |
+| Day | Input | Highest Price | Lowest Price | Maximum Loss |
 | --- | --- | --- | --- | --- |
 | 1 | 58000 | 58000 | 58000 | 0 |
 | 2 | 58700 | 58700 | 58700 | 0  |
@@ -26,29 +26,29 @@
 | 7 | 57700 | 58700 | 52700 | 6000 |
 | 8 | 61100 | 58700 | 52700 | 6000 |
 
-- Day2: 최악의 손실 기록을 위해 매수점을 Day2로 지정하는 경우, 매수점 이전의 시점인 Day1의 값은 무의미해집니다.
-- Day8: 최고가를 경신했지만 더 이상 팔 기회가 없으므로 최고가를 갱신하지 않습니다.
+- Day2: If we designate Day2 as the buying point for the worst possible loss record, the value of Day1, which is the previous point before the buying point, becomes meaningless.
+- Day8: Even though it reached the highest price, it is not updated since there is no more opportunity to sell.
 
-따라서 이 그래프에서의 최대 손실액은 6000원이 됩니다. 이처럼 입력값에 따른 최대의 손실 금액을 구하는 solution 함수를 작성해 봅시다.
-
----
-
-
-## 제한 사항
-
-- 0 < 주식 가격 < 1000000
+Therefore, the maximum loss amount for this graph is 6,000 won. Let's write a function to calculate the maximum loss amount according to the input value like this.
 
 ---
 
-## 입출력 예
 
-| 입력                                  | 출력  |
+## Constraints
+
+- 0 < stock price < 1000000
+
+---
+
+## Input and Output Examples
+
+| Input                                  | Output  |
 | ---------------------------------------- | ------- |
 | [58000, 58700, 55300, 54200, 53600, 52700, 57700, 61100] | 6000 |
 | [80000, 58000, 52700, 57700, 61100] | 27300 |
 
 ---
 
-## 입출력 설명
+## Explanation
 
-일자별 주식 가격을 입력받고 입력한 주식가격 안에서 실현할 수 있는 최대 손실액을 출력합니다.
+It takes daily stock prices as input and outputs the maximum loss amount that can be realized within the input stock prices.

--- a/src/py/testcase.py
+++ b/src/py/testcase.py
@@ -8,19 +8,19 @@ testcase_and_result = [{
 }, {
     "que_number": 1,
     "lv" : 0,
-    "kinds": "요구사항 구현",
+    "kinds": "Implementation",
     "testcase": [["  + + - + -+-", "  ++--+-+  ", "++ -+ -+-", "+++- +-+"], ["++-- -++", "++-- --+", "+++- +--"], ["++-++--", "++-+--+", "++-++++", "++-+++-"]],
     "result": ["jeju", "cat", "lion"]
 }, {
     "que_number": 2,
     "lv" : 1,
-    "kinds": "정규표현식",
+    "kinds": "Regular Expression",
     "testcase": ["adr10bb1d9ia10e33b7u88k3j1a3v11v9", "r1rr2rrr3rrrrr4rrrrrre5", "12345r12345e90v90r90"],
-    "result": ["2월 3일", "1월 5일", "2월 8일"]
+    "result": ["02.03", "01.05", "02.08"]
 }, {
     "que_number": 3,
     "lv" : 1,
-    "kinds": "정렬",
+    "kinds": "Sorting",
     "testcase": [
         [["A", 25, 24, 11, 12], ["B", 13, 22, 16, 14], ["C", 12, 22, 16, 14], ["D", 13, 22, 16, 14], ["E", 12, 25, 16, 19], [
             "F", 23, 15, 16, 14], ["G", 13, 14, 3, 5], ["H", 25, 22, 11, 14], ["I", 13, 12, 14, 23], ["J", 13, 22, 15, 14]],
@@ -33,19 +33,26 @@ testcase_and_result = [{
 }, {
     "que_number": 4,
     "lv" : 1,
-    "kinds": "정규표현식",
+    "kinds": "Regular Expression",
     "testcase": [["10 - A. 20 - B. 30 - A.", "1 - A. 1 - A. 1 - A. 1 - A. 2 - B. 1 - A. 1 - B"], ["10 a. 10 a. 10 a. 20 b. 30 c.", "c -- 100, c -- 100, c -- 100"], ["100만큼 a를 훈련. 200만큼 b를 훈련. 300만큼 c를 훈련. ", "100만큼 d를 훈련, 200만큼 e를 훈련"]],
-    "result": ["최종 꿈의 설계는 원래 미래 260, 바뀐 미래 14760입니다. 이 수치대로 Vision을 만듭니다.", "최종 꿈의 설계는 원래 미래 9000, 바뀐 미래 52000입니다. 이 수치대로 Vision을 만듭니다.", "미래가 보이지 않습니다."]
+    "result": [
+    "The final design for the dream is original future 260, changed future 37840. We create Vision according to these numbers.",
+    "The final design for the dream is original future 9000, changed future 52000. We create Vision according to these numbers.",
+    "The future is not visible."]
 }, {
     "que_number": 5,
     "lv" : 1,
-    "kinds": "행렬",
-    "testcase": [[10, 20], [30, 40], [50, 60]],
-    "result": [30, 70, 110]
+    "kinds": "Matrix",
+    "testcase": [
+        [[0, '#'], [0, 0]],
+        [[0, 0, '#', '#'], ['#', '#', 0, '#'], [0, '#', '#', 0]],
+        [['#', 0, 0, 0, '#'], [0, '#', '#', 0, 0], ['#', '#', '#', 0, '#'], ['#', 0, 0, '#', '#']]    
+    ],
+    "result": [[1, 3], [7, 16], [11, 29]]
 }, {
     "que_number": 6,
     "lv" : 1,
-    "kinds": "스택, 큐",
+    "kinds": "Stack, Queue",
     "testcase": [
         [1, 2, 3, 4, 1, 1, 2, 3, 4],
         [1, 1, 1, 2, 3, 4, 2, 3, 4, 1],
@@ -55,7 +62,7 @@ testcase_and_result = [{
 }, {
     "que_number": 7,
     "lv" : 1,
-    "kinds": "투포인터, 슬라이딩 윈도우",
+    "kinds": "Two Pointers, Sliding Window",
     "testcase": [
         [[4, 9, 11, 2], 6],
         [[2, 2], 4],
@@ -69,23 +76,22 @@ testcase_and_result = [{
 }, {
     "que_number": 8,
     "lv" : 0,
-    "kinds": "수학",
+    "kinds": "Math",
     "testcase": [100, 36000, 66600],
     "result": [0, 12, 24]
 }, {
     "que_number": 9,
     "lv" : 1,
-    "kinds": "투포인터, 슬라이딩 윈도우",
+    "kinds": "Two Pointers, Sliding Window",
     "testcase": [[58000, 58700, 55300, 54200, 53600, 52700, 57700, 61100], [80000, 58000, 52700, 57700, 61100], [100, 2000, 30000, 400000]],
     "result": [6000, 27300, 0]
 }, {
     "que_number": 10,
     "lv" : 1,
-    "kinds": "조합",
-    "testcase": [[0, ""], [2, "연어"], [3, ""]],
-    "result": ["기본 포케가 제공됩니다.", [["연어", "참치"], ["연어", "닭가슴살"], ["연어", "베이컨"], ["연어", "버섯"]],
-               [["연어", "참치", "닭가슴살"], ["연어", "참치", "베이컨"], ["연어", "참치", "버섯"], ["연어", "닭가슴살", "베이컨"], [
-                   "연어", "닭가슴살", "버섯"], ["연어", "베이컨", "버섯"], ["참치", "닭가슴살", "베이컨"], ["참치", "닭가슴살", "버섯"], ["닭고기", "베이컨", "버섯"]]
+    "kinds": "Combination",
+    "testcase": [[0, ""], [2, "salmon"], [3, ""]],
+    "result": ["Basic Poke will be provided.", [["salmon", "tuna"], ["salmon", "chicken"], ["salmon", "bacon"], ["salmon", "mushroom"]],
+               [["salmon", "tuna", "chicken"], ["salmon", "tuna", "bacon"], ["salmon", "tuna", "mushroom"], ["salmon", "chicken", "bacon"], ["salmon", "chicken", "mushroom"], ["salmon", "bacon", "mushroom"], ["tuna", "chicken", "bacon"], ["tuna", "chicken", "mushroom"], ["chicken", "bacon", "mushroom"]]
                ]
 }, {
     "que_number": 11,


### PR DESCRIPTION
## 완료된 사항
- ChatGPT 초안 번역
- 캐릭터 이름 수정
- 1번 문제 스토리북 및 강의 소개 부분 삭제
- 실행 페이지, chat AI 번역
- 5번 테스트케이스 수정

## 추가할 사항
- 대체 텍스트 번역
- 2번 문제 입출력 예시, 설명 변경 (테스트 케이스는 `["02.03", "01.05", "02.08"]`로 수정)
- 9번 문제 표 레이아웃
- 코드 블럭 예약어 처리 (현재 `while`, `for`만 다르게 표시)
![image](https://user-images.githubusercontent.com/80025366/230550001-f33c2165-066f-4874-af32-72443aa8918c.png)